### PR TITLE
Remove the fixed python version when running tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ skipdist = true
 
 [testenv]
 install_command = pip install {opts} {packages}
-basepython= python3.6
 whitelist_externals = 
   bash
   ls


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
Remove the fixed python version when running tox.
This is to test in python 3.6 or higher.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

