### PR TITLE
Fix memory bug when checking file type on windows

### DIFF
--- a/src/fosslight_binary/binary_analysis.py
+++ b/src/fosslight_binary/binary_analysis.py
@@ -206,6 +206,7 @@ def find_binaries(path_to_find_bin, output_dir, format, dburl=""):
 
 
 def return_bin_only(file_list, need_checksum_tlsh=True):
+    BYTES = 2048
     for file_item in file_list:
         is_bin_confirmed = False
         file_with_path = file_item.bin_name
@@ -215,10 +216,17 @@ def return_bin_only(file_list, need_checksum_tlsh=True):
             if stat.S_ISFIFO(os.stat(file_with_path).st_mode):
                 continue
             file_command_result = ""
+            file_command_failed = False
             try:
                 file_command_result = magic.from_file(file_with_path)
-            except Exception as ex:
-                logger.debug(f"Failed to check specific file type:{file_with_path}, {ex}")
+            except Exception:
+                file_command_failed = True
+            if file_command_failed:
+                try:
+                    file_command_result = magic.from_buffer(open(file_with_path).read(BYTES))
+                except Exception as ex:
+                    logger.debug(f"Failed to check file type:{file_with_path}, {ex}")
+
             if file_command_result:
                 file_command_result = file_command_result.lower()
                 if any(file_command_result.startswith(x) for x in _REMOVE_FILE_COMMAND_RESULT):


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
Fix memory bug when checking file type on windows. 
- Error message : 
     ``` 
    [ DEBUG] Failed to check specific file type:fosslight_dependency_scanner-main\fosslight_dependency_scanner-main\tests\test_npm2\node_modules\@babel\core\lib\index.js, b"line I64u: regex error 14 for `^[[:space:]]*class[[:space:]]+[[:digit:][:alpha:]:_]+[[:space:]]*\\{(.*[\n]*)*\\}(;)?$', (failed to get memory)"
     ```
- How to fix : If an issue of insufficient memory occurs when checking the file type, check the file by reading only 2048 bytes.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

