### PR TITLE
Use allowlist_externals instead of whitelist_externals

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ allowlist_externals =
   ls
   rm
   cat
+  {toxinidir}/dist/cli
 setenv =
   PYTHONPATH=.
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ skipdist = true
 
 [testenv]
 install_command = pip install {opts} {packages}
-whitelist_externals = 
+allowlist_externals = 
   bash
   ls
   rm


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
- Use allowlist_externals instead of whitelist_externals.
    whitelist_externals is now deprecated.
- Add cli to allowlist_externals.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

