### PR TITLE
Update package name for ARM Mac

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
                 'python-magic-bin'
             ],
             ':"darwin" in sys_platform': [
-                'python-magic-bin'
+                'python-magic'
             ],
             ':"linux" in sys_platform': [
                 'python-magic'


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
Update package name for ARM Mac.
- Error message when installing pip on Mac M2 chip:
```
 The conflict is caused by:
  fosslight-binary 4.1.15 depends on python-magic-bin; "darwin" in sys_platform
  fosslight-binary 4.1.14 depends on python-magic-bin; "darwin" in sys_platform
  fosslight-binary 4.1.13 depends on python-magic-bin; "darwin" in sys_platform
  fosslight-binary 4.1.12 depends on python-magic-bin; "darwin" in sys_platform
  fosslight-binary 4.1.11 depends on python-magic-bin; "darwin" in sys_platform
  fosslight-binary 4.1.10 depends on python-magic-bin; "darwin" in sys_platform
  fosslight-binary 4.1.9 depends on python-magic-bin; "darwin" in sys_platform
  fosslight-binary 4.1.8 depends on python-magic-bin; "darwin" in sys_platform
  fosslight-binary 4.1.7 depends on python-magic-bin; "darwin" in sys_platform
  fosslight-binary 4.1.6 depends on python-magic-bin; "darwin" in sys_platform
  fosslight-binary 4.1.5 depends on python-magic-bin; "darwin" in sys_platform
  fosslight-binary 4.1.4 depends on python-magic-bin; "darwin" in sys_platform
  fosslight-binary 4.1.3 depends on python-magic-bin; "darwin" in sys_platform
  fosslight-binary 4.1.2 depends on python-magic-bin; "darwin" in sys_platform
  fosslight-binary 4.1.1 depends on python-magic-bin; "darwin" in sys_platform
  fosslight-binary 4.1.0 depends on python-magic-bin; "darwin" in sys_platform
  fosslight-binary 4.0.9 depends on python-magic-bin; "darwin" in sys_platform
  fosslight-binary 4.0.8 depends on python-magic-bin; "darwin" in sys_platform
  fosslight-binary 4.0.7 depends on python-magic-bin; "darwin" in sys_platform
  fosslight-binary 4.0.6 depends on python-magic-bin; "darwin" in sys_platform
  fosslight-binary 4.0.5 depends on python-magic-bin; "darwin" in sys_platform
  fosslight-binary 4.0.4 depends on python-magic-bin; "darwin" in sys_platform
  fosslight-binary 4.0.3 depends on python-magic-bin; "darwin" in sys_platform
  fosslight-binary 4.0.2 depends on python-magic-bin; "darwin" in sys_platform
  fosslight-binary 4.0.1 depends on python-magic-bin; "darwin" in sys_platform
  fosslight-binary 4.0.0 depends on python-magic-bin; "darwin" in sys_platform
To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict
ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```
## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

