### PR TITLE
Add simple mode (-s option)

### DIFF
--- a/src/fosslight_binary/_help.py
+++ b/src/fosslight_binary/_help.py
@@ -14,6 +14,7 @@ _HELP_MESSAGE_BINARY = """
         -p <binary_path>\t\t    Path to analyze binaries (Default: current directory)
         -h\t\t\t\t    Print help message
         -v\t\t\t\t    Print FOSSLight Binary Scanner version
+        -s\t\t\t\t    Extract only the binary list in simple mode
         -o <output_path>\t\t    Output path
         \t\t\t\t    (If you want to generate the specific file name, add the output path with file name.)
         -f <format>\t\t\t    Output file format (excel, csv, opossum, yaml)

--- a/src/fosslight_binary/cli.py
+++ b/src/fosslight_binary/cli.py
@@ -19,10 +19,12 @@ def main():
     output_dir = ""
     format = ""
     db_url = ""
+    simple_mode = False
 
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument('-h', '--help', action='store_true', required=False)
     parser.add_argument('-v', '--version', action='store_true', required=False)
+    parser.add_argument('-s', '--simple', action='store_true', required=False)
     parser.add_argument('-p', '--path', type=str, required=False)
     parser.add_argument('-o', '--output', type=str, required=False)
     parser.add_argument('-d', '--dburl', type=str, default='', required=False)
@@ -41,6 +43,9 @@ def main():
     if args.version:    # -v option
         print_package_version(_PKG_NAME, "FOSSLight Binary Scanner Version:")
         sys.exit(0)
+
+    if args.simple:
+        simple_mode = True
 
     if args.path:   # -p option
         path_to_find_bin = args.path
@@ -73,7 +78,7 @@ def main():
     timer.setDaemon(True)
     timer.start()
 
-    find_binaries(path_to_find_bin, output_dir, format, db_url)
+    find_binaries(path_to_find_bin, output_dir, format, db_url, simple_mode)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
Add simple mode. (-s option)
- If you run in simple mode, you can check the existence of binary and only the binary list as log.
- Execution result of simple mode :
   ```
  % fosslight_binary -p tests -s
  [FOSSLIGHT_BINARY] Binaries / Scanned files: 3/11
  Binary list:
  - tests/askalono_macos
  - tests/error_prone_annotations-2.7.1.jar
  - tests/test/askalono_macos
  Execution result: Success
   ```

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

