### PR TITLE
Bug fix to print jar analysis

### DIFF
--- a/src/fosslight_binary/_binary.py
+++ b/src/fosslight_binary/_binary.py
@@ -130,12 +130,12 @@ class BinaryItem:
                 else:
                     comment = oss.comment
 
-                yield from [self.binary_strip_root, oss.name, oss.version,
-                            oss.license, oss.dl_url, '', '', exclude, comment, nvd_url]
+                yield [self.binary_strip_root, oss.name, oss.version,
+                       oss.license, oss.dl_url, '', '', exclude, comment, nvd_url]
         else:
             exclude = _EXCLUDE_TRUE_VALUE if self.exclude else ""
-            yield from [self.binary_strip_root, '',
-                        '', '', '', '', '', exclude, self.comment]
+            yield [self.binary_strip_root, '',
+                   '', '', '', '', '', exclude, self.comment]
 
     def set_checksum_tlsh(self):
         self.checksum, self.tlsh, error, msg = get_checksum_and_tlsh(

--- a/src/fosslight_binary/binary_analysis.py
+++ b/src/fosslight_binary/binary_analysis.py
@@ -180,7 +180,8 @@ def find_binaries(path_to_find_bin, output_dir, format, dburl="", simple_mode=Fa
                     error_occured(error_msg=error, exit=False)
 
             sheet_list = {}
-            content_list = [list(item.get_oss_report()) for item in return_list]
+            for item in return_list:
+                content_list.extend(item.get_oss_report())
             sheet_list["BIN_FL_Binary"] = content_list
 
             success_to_write, writing_msg, result_file = write_output_file(result_report, output_extension, sheet_list, extended_header)


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
 - Bug fix to print jar analysis.
     - AS-IS : As a result of jar file analysis, when there are multiple OSSs, the information for each OSS was not classified. In other words, the two OSS information are connected and output.
    - TO-BE: When there are multiple OSS, information on one OSS is divided into a separate list and output as an excel file.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

