### PR TITLE
Merge OSS info result to one row

### DIFF
--- a/src/fosslight_binary/_binary.py
+++ b/src/fosslight_binary/_binary.py
@@ -83,6 +83,9 @@ class BinaryItem:
         # Append New input OSS
         self.oss_items.extend(new_oss_list)
 
+    def get_oss_items(self):
+        return self.oss_items
+
     def set_vulnerability_items(self, vul_list):
         if vul_list is not None:
             self.vulnerability_items.extend(vul_list)

--- a/src/fosslight_binary/_binary_dao.py
+++ b/src/fosslight_binary/_binary_dao.py
@@ -30,18 +30,17 @@ def get_oss_info_from_db(bin_info_list, dburl=""):
             tlsh_value = item.tlsh
             checksum_value = item.checksum
             bin_file_name = item.binary_name_without_path
-            comment_msg = "Binary DB Result / Excluded due to OWASP result." if item.found_in_owasp else "Binary DB Result."
 
             df_result = get_oss_info_by_tlsh_and_filename(
                 bin_file_name, checksum_value, tlsh_value)
             if df_result is not None and len(df_result) > 0:
                 _cnt_auto_identified += 1
                 for idx, row in df_result.iterrows():
-                    oss_from_db = OssItem(
-                        row['ossname'], row['ossversion'], row['license'])
-                    oss_from_db.set_comment(comment_msg)
-                    oss_from_db.set_exclude(item.found_in_owasp)
-                    bin_oss_items.append(oss_from_db)
+                    # If binary is not found in OWASP, append OSS info.
+                    if not item.found_in_owasp:
+                        oss_from_db = OssItem(row['ossname'], row['ossversion'], row['license'])
+                        bin_oss_items.append(oss_from_db)
+                        item.set_comment("Binary DB result")
 
                 if bin_oss_items:
                     item.set_oss_items(bin_oss_items)

--- a/src/fosslight_binary/_jar_analysis.py
+++ b/src/fosslight_binary/_jar_analysis.py
@@ -253,7 +253,7 @@ def analyze_jar_file(path_to_find_bin):
 
             if oss_name != "" or oss_ver != "" or oss_license != "" or oss_dl_url != "":
                 oss = OssItem(oss_name, oss_ver, oss_license, oss_dl_url)
-                oss.set_comment("OWASP Result. ")
+                oss.set_comment("OWASP result")
 
                 remove_owasp_item = owasp_items.get(file_with_path)
                 if remove_owasp_item:


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
- Merge oss info result to one row
    - If binary's OSS info is in  both OWASP and Binary DB,
            - AS-IS : Print both result each row + Exclude Binary DB's result
            - TO-BE : Print only one row (OWASP result)


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

