### PR TITLE
Enable multiple input for -f option

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ py-tlsh
 pytz
 XlsxWriter
 PyYAML
-fosslight_util>=1.4.43
+fosslight_util>=1.4.47
 dependency-check

--- a/src/fosslight_binary/_help.py
+++ b/src/fosslight_binary/_help.py
@@ -18,7 +18,8 @@ _HELP_MESSAGE_BINARY = """
         -e <path>\t\t\t    Path to exclude from analysis (files and directories)
         -o <output_path>\t\t    Output path
         \t\t\t\t    (If you want to generate the specific file name, add the output path with file name.)
-        -f <format>\t\t\t    Output file format (excel, csv, opossum, yaml)
+        -f <format> [<format> ...]\t    Output file formats (excel, csv, opossum, yaml)
+        \t\t\t\t    Multiple formats can be specified separated by space.
         -d <db_url>\t\t\t    DB Connection(format :'postgresql://username:password@host:port/database_name')
         --notice\t\t\t    Print the open source license notice text.
         --no_correction\t\t\t    Enter if you don't want to correct OSS information with sbom-info.yaml

--- a/src/fosslight_binary/cli.py
+++ b/src/fosslight_binary/cli.py
@@ -30,7 +30,7 @@ def main():
     parser.add_argument('-p', '--path', type=str, required=False)
     parser.add_argument('-o', '--output', type=str, required=False)
     parser.add_argument('-d', '--dburl', type=str, default='', required=False)
-    parser.add_argument('-f', '--format', type=str, required=False)
+    parser.add_argument('-f', '--formats', type=str, required=False, nargs="*")
     parser.add_argument('-e', '--exclude', nargs="*", required=False, default=[])
     parser.add_argument('--notice', action='store_true', required=False)
     parser.add_argument('--no_correction', action='store_true', required=False)
@@ -66,8 +66,8 @@ def main():
     if args.dburl:  # -d option
         db_url = args.dburl
 
-    if args.format:  # -f option
-        format = args.format
+    if args.formats:  # -f option
+        format = list(args.formats)
 
     if args.no_correction:
         correct_mode = False

--- a/tox.ini
+++ b/tox.ini
@@ -48,3 +48,4 @@ commands =
   pyinstaller --onefile cli.py -n cli --additional-hooks-dir=hooks --hidden-import=pkg_resources.extern
   {toxinidir}/dist/cli -p tests -o test_result_cli
   ; py.test --cov-report term-missing --cov={envsitepackagesdir}/fosslight_binary
+ 


### PR DESCRIPTION
## Description
Enable multiple input for -f option

Example 1)
Command : $fosslight_binary **-o abc/output.xlsx -f csv excel**
Output
 - abc/fosslight_log_bin_YYMMDD_HHMM.txt
 - abc/output.**csv**
 - abc/output.**xlsx**

Example 2)
Command : $fosslight_binary **-o abc -f csv excel**
Output
 - abc/fosslight_log_bin_YYMMDD_HHMM.txt
 - abc/fosslight_report_bin_YYMMDD_HHMM.**csv**
 - abc/fosslight_report_bin_YYMMDD_HHMM.**xlsx**

Example 3)
Command : $fosslight_binary **-f csv excel**
Output
 - fosslight_log_bin_YYMMDD_HHMM.txt
 - fosslight_report_bin_YYMMDD_HHMM.**csv**
 - fosslight_report_bin_YYMMDD_HHMM.**xlsx**

Example 4)
Command : $fosslight_binary **-o abc/output.json -f csv excel**
Error : 
> Format error - The format of output file(-o:'abc/output.json') should be in the format list(-f:'['csv', 'excel']').
Output
 - N/A

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

