### PR TITLE
Remove duplicates from OSS information loaded from Binary DB

### DIFF
--- a/src/fosslight_binary/_binary.py
+++ b/src/fosslight_binary/_binary.py
@@ -28,8 +28,9 @@ class BinaryItem(FileItem):
         self.vulnerability_items = []
         self.binary_name_without_path = ""
         self.bin_name_with_path = value
-        self.found_in_owasp = False
         self.is_binary = True
+        self.found_in_owasp = False
+        self.found_in_bin_db = False  # for debugging
 
     def __del__(self):
         pass

--- a/src/fosslight_binary/_binary_dao.py
+++ b/src/fosslight_binary/_binary_dao.py
@@ -43,11 +43,20 @@ def get_oss_info_from_db(bin_info_list, dburl=""):
                 for idx, row in df_result.iterrows():
                     if not item.found_in_owasp:
                         oss_from_db = OssItem(row['ossname'], row['ossversion'], row['license'])
-                        bin_oss_items.append(oss_from_db)
+
+                        if bin_oss_items:
+                            if not any(oss_item.name == oss_from_db.name
+                                       and oss_item.version == oss_from_db.version
+                                       and oss_item.license == oss_from_db.license
+                                       for oss_item in bin_oss_items):
+                                bin_oss_items.append(oss_from_db)
+                        else:
+                            bin_oss_items.append(oss_from_db)
 
                 if bin_oss_items:
                     item.set_oss_items(bin_oss_items)
                     item.comment = "Binary DB result"
+                    item.found_in_binary = True
 
     disconnect_lge_bin_db()
     return bin_info_list, _cnt_auto_identified


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
Remove duplicate OSS from Binary DB.
- Duplicate condition: If oss name, oss version, and license are the same.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

