### PR TITLE
Change the minimum Python version to 3.10

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -62,8 +62,8 @@ jobs:
             TARGET: ubuntu
             CMD_BUILD: >
                 pyinstaller --onefile cli.py -n cli --additional-hooks-dir=hooks --hidden-import=pkg_resources.extern --add-binary "LICENSE:LICENSES" --add-binary "LICENSES/LicenseRef-3rd_party_licenses.txt:LICENSES" &&
-                mv dist/cli fosslight_bin_ubuntu18
-            OUT_FILE_NAME: fosslight_bin_ubuntu18
+                mv dist/cli fosslight_bin_ubuntu
+            OUT_FILE_NAME: fosslight_bin_ubuntu
             ASSET_MIME: application/octet-stream
           - os: macos-latest
             TARGET: macos

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -40,10 +40,10 @@ jobs:
         python-version: [3.12.x]
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.12
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
-        python-version: '3.12.x'
+        python-version: ${{ matrix.python-version }}
     - name: Install & Run
       run: |
         python -m pip install --upgrade pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ binaryornot
 numpy
 pandas
 parmap
-psycopg2-binary==2.9.9
+psycopg2-binary
 python-dateutil
 py-tlsh
 pytz

--- a/setup.py
+++ b/setup.py
@@ -45,10 +45,10 @@ if __name__ == "__main__":
         download_url='https://github.com/fosslight/fosslight_binary_scanner',
         classifiers=['License :: OSI Approved :: Apache Software License',
                      "Programming Language :: Python :: 3",
-                     "Programming Language :: Python :: 3.6",
-                     "Programming Language :: Python :: 3.7",
-                     "Programming Language :: Python :: 3.8",
-                     "Programming Language :: Python :: 3.9", ],
+                     "Programming Language :: Python :: 3.10",
+                     "Programming Language :: Python :: 3.11",
+                     "Programming Language :: Python :: 3.12"],
+        python_requires='>=3.10,<3.13',
         install_requires=install_requires,
         extras_require={
             ':sys_platform == "win32"': [


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
Change the minimum Python version to 3.10.
- Python3.9 official support ends in October 25.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

