### PR TITLE
Move log file from temp dir to final output dir before cleanup

### DIFF
--- a/src/fosslight_binary/binary_analysis.py
+++ b/src/fosslight_binary/binary_analysis.py
@@ -12,7 +12,7 @@ import magic
 import logging
 import yaml
 import stat
-from fosslight_util.set_log import init_log
+from fosslight_util.set_log import init_log, move_log_file
 import fosslight_util.constant as constant
 from fosslight_util.output_format import check_output_formats_v2, write_output_file
 from ._binary_dao import get_oss_info_from_db
@@ -132,7 +132,7 @@ def init(path_to_find_bin, output_file_name, formats, path_to_exclude=[]):
         error_occured(error_msg=msg,
                       result_log=_result_log,
                       exit=True)
-    return _result_log, combined_paths_and_files, output_extensions, formats, output_path, original_output_path
+    return _result_log, combined_paths_and_files, output_extensions, formats, output_path, original_output_path, log_file
 
 
 def get_file_list(path_to_find, excluded_files):
@@ -181,7 +181,7 @@ def find_binaries(path_to_find_bin, output_dir, formats, dburl="", simple_mode=F
         mode = "Simple Mode"
         _result_log, compressed_list_txt, simple_bin_list_txt = init_simple(output_dir, PKG_NAME, start_time)
     else:
-        _result_log, result_reports, output_extensions, formats, output_path, original_output_path = init(
+        _result_log, result_reports, output_extensions, formats, output_path, original_output_path, log_file = init(
             path_to_find_bin, output_dir, formats, path_to_exclude)
 
     total_bin_cnt = 0
@@ -280,6 +280,7 @@ def find_binaries(path_to_find_bin, output_dir, formats, dburl="", simple_mode=F
                 logger.error(f"Fail to generate result file.:{writing_msg}")
 
     try:
+        move_log_file(log_file, os.path.join(original_output_path, f"fosslight_log_bin_{start_time}.txt"))
         shutil.copytree(output_path, original_output_path, dirs_exist_ok=True)
         shutil.rmtree(output_path)
     except Exception as ex:

--- a/src/fosslight_binary/binary_analysis.py
+++ b/src/fosslight_binary/binary_analysis.py
@@ -279,12 +279,16 @@ def find_binaries(path_to_find_bin, output_dir, formats, dburl="", simple_mode=F
             else:
                 logger.error(f"Fail to generate result file.:{writing_msg}")
 
-    try:
-        move_log_file(log_file, os.path.join(original_output_path, f"fosslight_log_bin_{start_time}.txt"))
-        shutil.copytree(output_path, original_output_path, dirs_exist_ok=True)
-        shutil.rmtree(output_path)
-    except Exception as ex:
-        logger.debug(f"Failed to move temp files: {ex}")
+        try:
+            move_log_file(log_file, os.path.join(original_output_path, f"fosslight_log_bin_{start_time}.txt"))
+        except Exception as ex:
+            logger.debug(f"Failed to move log file: {ex}")
+
+        try:
+            shutil.copytree(output_path, original_output_path, dirs_exist_ok=True)
+            shutil.rmtree(output_path)
+        except Exception as ex:
+            logger.debug(f"Failed to move temp files: {ex}")
 
     try:
         print_result_log(mode=mode, success=True, result_log=_result_log,

--- a/src/fosslight_binary/cli.py
+++ b/src/fosslight_binary/cli.py
@@ -61,6 +61,7 @@ def main():
 
     if args.help:  # -h option
         print_help_msg()
+        sys.exit(0)
 
     if args.version:    # -v option
         print_package_version(_PKG_NAME, "FOSSLight Binary Scanner Version:")

--- a/tests/initial_tox_test.py
+++ b/tests/initial_tox_test.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import glob
 import subprocess
 import shutil
 import pytest
@@ -40,12 +41,11 @@ def test_test_run_environment():  # 테스트 환경 tox.ini
         "-f", "csv"
     )
 
-    files_in_result = run_command("ls", "test_result")[1].split()
-    txt_success, txt_output = run_command("find", "test_result", "-type", "f", "-name", "fosslight_log*.txt")
+    files_in_result = os.listdir(TEST_RESULT_DIR)
+    txt_files = glob.glob(os.path.join(TEST_RESULT_DIR, "**", "fosslight_log*.txt"), recursive=True)
 
     # Then
     csv_files = [f for f in files_in_result if f.endswith('.csv')]
-    txt_files = txt_output.split()
     assert csv_success is True, "Test Run Environment: CSV files not properly created (not create)"
     assert len(csv_files) > 0, "Test Run Environment: CSV files not properly created (length)"
     assert exclude_success is True, "Test Run Environment: Exclude feature fail"
@@ -65,7 +65,7 @@ def test_release_environment():  # 릴리즈 환경 tox.ini
     )
 
     json_success, _ = run_command("fosslight_bin", "-p", ".", "-o", "test_result/result.json", "-f", "opossum")
-    files_in_result = run_command("ls", "test_result")[1].split()
+    files_in_result = os.listdir(TEST_RESULT_DIR)
 
     # Then
     required_files = ['result.csv', 'exclude_result.csv', 'result.json']


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Log files generated during binary analysis are now moved into the final output folder so they appear with other artifacts.
  * Displaying the help message now exits immediately after printing, preventing further execution.
* **Tests**
  * Updated tests to use Python filesystem APIs (os.listdir/glob) instead of shell commands for discovery and assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->