### PR TITLE
chore(simple_mode): hide simple mode from help message and CLI option

### DIFF
--- a/src/fosslight_binary/_help.py
+++ b/src/fosslight_binary/_help.py
@@ -32,7 +32,6 @@ _HELP_MESSAGE_BINARY = f"""
 
     🔍 Scanner-Specific Options
     ────────────────────────────────────────────────────────────────────
-    -s                     Extract only the binary list in simple mode
     -d <db_url>            DB Connection (format: 'postgresql://user:pass@host:port/db')
     --notice               Print the open source license notice text
     --no_correction        Skip OSS information correction with sbom-info.yaml
@@ -48,9 +47,6 @@ _HELP_MESSAGE_BINARY = f"""
 
     # Generate output in specific format
     fosslight_bin -f excel -o results/
-
-    # Simple mode (extract binary list only)
-    fosslight_bin -s -o binary_list.txt
 
     # Connect to Binary DB for OSS information
     fosslight_bin -d "postgresql://user:pass@localhost:5432/exampledb"

--- a/src/fosslight_binary/cli.py
+++ b/src/fosslight_binary/cli.py
@@ -43,7 +43,7 @@ def main():
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument('-h', '--help', action='store_true', required=False)
     parser.add_argument('-v', '--version', action='store_true', required=False)
-    parser.add_argument('-s', '--simple', action='store_true', required=False)
+    parser.add_argument('-s', '--simple', action='store_true', required=False, help=argparse.SUPPRESS)
     parser.add_argument('-p', '--path', type=str, required=False)
     parser.add_argument('-o', '--output', type=str, required=False)
     parser.add_argument('-d', '--dburl', type=str, default='', required=False)


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
- Remove `-s` option and its example from _help.py
- Suppress `-s`/`--simple` argument in argparse to hide from help output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Removed the documented "-s/--simple" (simple mode) option from the command-line help and from example usage.
  * The option is no longer shown in help output or examples, though the runtime behavior and defaults remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->