### PR TITLE
Remove 'data' from _REMOVE_FILE_COMMAND_RESULT

### DIFF
--- a/src/fosslight_binary/binary_analysis.py
+++ b/src/fosslight_binary/binary_analysis.py
@@ -33,8 +33,7 @@ PKG_NAME = "fosslight_binary"
 logger = logging.getLogger(constant.LOGGER_NAME)
 
 _REMOVE_FILE_EXTENSION = ['json', 'js']
-_REMOVE_FILE_COMMAND_RESULT = [
-    'data', 'timezone data', 'apple binary property list']
+_REMOVE_FILE_COMMAND_RESULT = ['timezone data', 'apple binary property list']
 INCLUDE_FILE_COMMAND_RESULT = ['current ar archive']
 
 _error_logs = []
@@ -320,7 +319,7 @@ def check_binary(file_with_path, skip_remove_file_command_result: bool = False):
     """
     :param file_with_path: Path to the file to classify.
     :param skip_remove_file_command_result: If True, do not treat
-        _REMOVE_FILE_COMMAND_RESULT magic prefixes (e.g. 'data') as non-binary.
+        _REMOVE_FILE_COMMAND_RESULT magic prefixes as non-binary.
     """
     is_bin_confirmed = False
     file = os.path.basename(file_with_path)


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
AI/ML model and dataset files (e.g. ONNX, TFLite, TF Checkpoint, SafeTensors, GGUF, Caffe, GGML, word2vec, LevelDB, LMDB, MXNet, MessagePack) return 'data' from magic, causing check_binary() to incorrectly return False and skip them entirely.

Remove 'data' from _REMOVE_FILE_COMMAND_RESULT so that these files proceed to the is_binary() check via binaryornot, which correctly identifies them as binary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved binary file classification accuracy. The detection algorithm has been refined to correctly identify binary files that were previously misclassified as non-binary. This results in enhanced reliability and precision of analysis across diverse file formats and improved overall system performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->