### PR TITLE
Fix source files incorrectly included in binary results on Windows exe

### DIFF
--- a/hooks/hook-fosslight_binary.py
+++ b/hooks/hook-fosslight_binary.py
@@ -12,3 +12,15 @@ datas_binaryornot, binaries_binaryornot, hiddenimports_binaryornot = collect_all
 datas += datas_binaryornot
 binaries += binaries_binaryornot
 hiddenimports += hiddenimports_binaryornot
+
+# Collect python-magic / python-magic-bin (magic database and DLLs)
+datas_magic, binaries_magic, hiddenimports_magic = collect_all('magic')
+datas += datas_magic
+binaries += binaries_magic
+hiddenimports += hiddenimports_magic
+
+# Collect rfc3987_syntax data files (.lark grammar file)
+datas_rfc, binaries_rfc, hiddenimports_rfc = collect_all('rfc3987_syntax')
+datas += datas_rfc
+binaries += binaries_rfc
+hiddenimports += hiddenimports_rfc

--- a/src/fosslight_binary/binary_analysis.py
+++ b/src/fosslight_binary/binary_analysis.py
@@ -308,10 +308,10 @@ def return_bin_only(file_list, need_checksum_tlsh=True):
                 if need_checksum_tlsh:
                     file_item.checksum, file_item.tlsh, error_msg = get_checksum_and_tlsh(file_item.bin_name_with_path)
                     if error_msg:
-                        error_occured(modeerror_msg=error_msg, exit=False)
+                        error_occured(error_msg=error_msg, exit=False)
                 yield file_item
         except Exception as ex:
-            logger.debug(f"Exception in get_file_list: {ex}")
+            logger.debug(f"Exception in check_binary: {ex}")
             file_item.comment = "Exclude or delete if it is not binary."
             yield file_item
 
@@ -336,7 +336,7 @@ def check_binary(file_with_path, skip_remove_file_command_result: bool = False):
             file_command_failed = True
         if file_command_failed:
             try:
-                file_command_result = magic.from_buffer(open(file_with_path).read(BYTES))
+                file_command_result = magic.from_buffer(open(file_with_path, 'rb').read(BYTES))
             except Exception as ex:
                 logger.debug(f"Failed to check file type:{file_with_path}, {ex}")
 


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
- Fix typo in keyword argument: modeerror_msg -> error_msg
- Fix magic.from_buffer() to open files in binary mode ('rb') to avoid encoding errors and incorrect magic detection on Windows
- Add python-magic and rfc3987_syntax data collection to PyInstaller hook   to ensure magic database and .lark grammar file are bundled in the exe
