### PR TITLE
Fix binaryornot to 0.4.4 to prevent misclassification errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 requires-python = ">=3.10,<3.15"
 dependencies = [
-    "binaryornot",
+    "binaryornot==0.4.4",
     "chardet<5.0.0",
     "numpy",
     "pandas",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Fix `binaryornot` dependency to version 0.4.4.

* binaryornot 0.6.0 introduced a scikit-learn-based decision tree algorithm
that misclassifies C/H source files containing EUC-KR (Korean) encoded
comments as binary.

* Root cause:
    * 0.4.4: uses chardet to detect encoding → decodes successfully as EUC-KR
      → correctly classified as text
    * 0.6.0: uses a trained decision tree that checks utf8_valid as a key
   feature. EUC-KR files are not valid UTF-8, so utf8_valid=0.0.
  Combined with high byte entropy from multi-byte Korean characters,
  the tree classifies them as binary — even though try_euc_kr=1.0
  is present, that feature is not evaluated on the path these files take.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->