### PR TITLE
Remove the temp dir and exclude excel files

### DIFF
--- a/src/fosslight_binary/binary_analysis.py
+++ b/src/fosslight_binary/binary_analysis.py
@@ -32,7 +32,7 @@ import shutil
 PKG_NAME = "fosslight_binary"
 logger = logging.getLogger(constant.LOGGER_NAME)
 
-_REMOVE_FILE_EXTENSION = ['json', 'js']
+_REMOVE_FILE_EXTENSION = ['json', 'js', 'xlsx', 'xls', 'xlsm']
 _REMOVE_FILE_COMMAND_RESULT = ['timezone data', 'apple binary property list']
 INCLUDE_FILE_COMMAND_RESULT = ['current ar archive']
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved binary analysis cleanup by isolating temporary files for each run.
  * Ensured temporary data is removed after both successful and interrupted analyses.
  * Prevented temporary analysis data from being included in file scans.
* **Reliability**
  * Improved consistency when publishing analysis artifacts and finalizing logs.
  * Prevented cleanup from affecting temporary data belonging to other analyses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->